### PR TITLE
Several fixes and webmirror capabilities

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,8 @@
 ---
 driver:
   name: vagrant
+  network:
+  - ["forwarded_port", {guest: 80, host: 8000}]
 
 provisioner:
   name: chef_solo
@@ -15,4 +17,9 @@ suites:
   - name: default
     run_list:
       - recipe[apt]
+      - recipe[ubumirror]
+  -name: webmirror
+    run_list:
+      - recipe[apt]
+      - recipe[apache2]
       - recipe[ubumirror]

--- a/Berksfile
+++ b/Berksfile
@@ -3,3 +3,4 @@ source 'https://supermarket.chef.io'
 metadata
 
 cookbook 'apt'
+cookbook 'apache2', '>= 2.0.0'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Installs and configures [Ubumirror](https://launchpad.net/ubumirror).
 
 ## Supported Platforms
 
-Ubuntu 12.04
+Ubuntu 12.04 (not webmirror)
 Ubuntu 14.04
 
 ## Attributes
@@ -177,6 +177,24 @@ Ubuntu 14.04
       Contents-powerpc.gz
       Contents-sparc.gz
     )</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['ubumirror']['apache']['enable']</tt></td>
+    <td>Boolean</td>
+    <td>Enables apache webmirror capabilities</td>
+    <td><tt>false</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['ubumirror']['apache']['port']</tt></td>
+    <td>Integer</td>
+    <td>The port for apache to listen to for the ubumirror vhost</td>
+    <td><tt>80</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['ubumirror']['apache']['docroot']</tt></td>
+    <td>String</td>
+    <td>The document root for the ubumirror webmirror</td>
+    <td><tt>/srv/mirror</tt></td>
   </tr>
 </table>
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,10 @@ default['ubumirror']['ubucdi_enable'] = false
 default['ubumirror']['uburel_enable'] = false
 default['ubumirror']['ubupor_enable'] = false
 
+default['ubumirror']['apache']['enable'] = false
+default['ubumirror']['apache']['port'] = 80
+default['ubumirror']['apache']['docroot'] = '/srv/mirror'
+
 default['ubumirror']['ubuarc_dir'] = '/srv/mirror/ubuntu'
 default['ubumirror']['ubucdi_dir'] = '/srv/mirror/ubuntu-cdimage'
 default['ubumirror']['uburel_dir'] = '/srv/mirror/ubuntu-releases'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,3 +5,5 @@ license          'Apache 2.0'
 description      'Installs/Configures ubumirror'
 long_description 'Installs/Configures ubumirror'
 version          '0.1.0'
+
+depends 'apache2'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,11 @@ user 'ubumirror' do
   system true
 end
 
+apt_repository 'ubumirror' do
+  uri 'ppa:ubumirror-devs/ubumirror'
+  distribution 'trusty'
+end
+
 package 'ubumirror' do
   action :upgrade
 end
@@ -64,6 +69,36 @@ template '/etc/ubumirror.conf' do
     uburel_exclude: node['ubumirror']['uburel_exclude'],
     ubupor_exclude: node['ubumirror']['ubupor_exclude']
   )
+end
+
+if node['ubumirror']['apache']['enable']
+
+  apache_module 'headers' do
+    enable true
+  end
+
+  apache_module 'expires' do
+    enable true
+  end
+
+  apache_conf 'webmirror' do
+    enable true
+  end
+
+  web_app 'ubumirror' do
+    template 'apache2/ubumirror.erb'
+    docroot node['ubumirror']['apache']['docroot']
+    server_name node['ubumirror']['hostname']
+    port node['ubumirror']['apache']['port']
+  end
+
+end
+
+directory '/var/log/ubumirror' do
+  owner 'ubumirror'
+  group 'root'
+  mode '0755'
+  action :create
 end
 
 cron 'ubuarchive' do

--- a/templates/default/apache2/ubumirror.erb
+++ b/templates/default/apache2/ubumirror.erb
@@ -1,0 +1,53 @@
+# This will
+
+Listen <%= @params[:port] %>
+
+<VirtualHost *>
+
+        ServerName <%= @params[:server_name] %>
+
+        DocumentRoot <%= @params[:docroot] %>
+
+        <Directory />
+                IndexOptions NameWidth=* +SuppressDescription
+                Options +Indexes +FollowSymLinks
+                IndexIgnore favicon.ico
+        </Directory>
+
+        # Munge the Cache-Control/Expires response headers to try make
+        # transparent proxy servers DTRT.
+        # This is used by the main Ubuntu archives.
+        <Files ~ "Release(\.gpg)?|Packages\.(bz2|gz)|Sources\.(bz2|gz)?$">
+                ExpiresActive On
+                ExpiresDefault "modification plus 3300 seconds"
+                # In case a shared cache keeps a copy of the file, explicitely
+                # set the expiry time.
+                Header append Cache-Control "s-maxage=3300"
+                # Proxies (shared caches) must re-obtain the file if it's older
+                # than s-maxage (they can never serve it if it's stale).
+                Header append Cache-Control "proxy-revalidate"
+                # It's ok to serve the same content so several different users.
+                Header append Cache-Control "public"
+        </Files>
+
+        # Set public cache control and a max age of 2 weeks for the debs and
+        # other files with a versionned URL.
+        <FilesMatch "\.(deb|iso|torrent|zsync)$">
+                ExpiresActive On
+                # Keep the file for two weeks - no matter if it's been modified
+                # recently or not.
+                ExpiresDefault "access plus 1209600 seconds"
+                # It's ok to share the same content between users.
+                Header append Cache-Control "public"
+        </FilesMatch>
+
+        # Possible values include: debug, info, notice, warn, error, crit,
+        # alert, emerg.
+        LogLevel warn
+
+        CustomLog /var/log/apache2/ubuntu-mirror_access.log combined
+        ErrorLog /var/log/apache2/ubuntu-mirror_error.log
+
+        ServerSignature On
+
+</VirtualHost>

--- a/templates/default/ubumirror.conf.erb
+++ b/templates/default/ubumirror.conf.erb
@@ -44,11 +44,7 @@ UBUCDI_FLAVOURS="\
   <%= @ubucdi_flavours.join(" \\ \n  ") %>"
 
 # UBU{ARC,CDI,REL}_EXCLUDE is what things you want to exclude
-UBUARC_EXCLUDE="\
-  <%= @ubuarc_exclude.join(" \\ \n  ") %>"
-UBUCDI_EXCLUDE="\
-  <%= @ubucdi_exclude.join(" \\ \n  ") %>"
-UBUREL_EXCLUDE="\
-  <%= @uburel_exclude.join(" \\ \n  ") %>"
-UBUPOR_EXCLUDE="\
-  <%= @ubupor_exclude.join(" \\ \n  ") %>"
+UBUARC_EXCLUDE="--exclude <%= @ubuarc_exclude.join(" --exclude ") %>"
+UBUCDI_EXCLUDE="--exclude <%= @ubucdi_exclude.join(" --exclude ") %>"
+UBUREL_EXCLUDE="--exclude <%= @uburel_exclude.join(" --exclude ") %>"
+UBUPOR_EXCLUDE="--exclude <%= @ubupor_exclude.join(" --exclude ") %>"

--- a/templates/default/webmirror.conf.erb
+++ b/templates/default/webmirror.conf.erb
@@ -1,0 +1,5 @@
+<Directory <%= node[:ubumirror][:apache][:docroot] %>>
+       Options Indexes FollowSymLinks
+       AllowOverride None
+       Require all granted
+</Directory>


### PR DESCRIPTION
- fixed syntax for excludes in config file to work with the version of ubumirror in ubuntu 14.04
- added webmirror capabilities (ubuntu 14.04 only)
- updated README

I would suggest, if this is merged, to also make a bigger version jump, since there is quite a lot of stuff changed and the webmirror stuff only works for ubuntu 14.04. Unfortunatly, apache version changed and some config files won't work in one of the two. I decided to support the newer version.
